### PR TITLE
Remove extra semicolon and improve formatting

### DIFF
--- a/templates/default/classifier-bayes.conf.erb
+++ b/templates/default/classifier-bayes.conf.erb
@@ -1,14 +1,14 @@
 <% if node['rspamd']['redis']['servers'].nil? %>
-  backend = "sqlite3";
+backend = "sqlite3";
 <% else %>
-  backend = "redis";
-  servers = "<%= node['rspamd']['redis']['servers'].join(',') %>";
+backend = "redis";
+servers = "<%= node['rspamd']['redis']['servers'].join(',') %>";
 <% end %>
 
 <% unless node['rspamd']['bayes-classifier']['per_user'].nil? %>
 per_user = <%= node['rspamd']['bayes-classifier']['per_user'].to_s %>;
 <% end %>
 
-<% unless node['rspamd']['bayes-classifier']['autolearn'].nil? %>;
+<% unless node['rspamd']['bayes-classifier']['autolearn'].nil? %>
 autolearn = <%= node['rspamd']['bayes-classifier']['autolearn'].to_s %>;
 <% end %>


### PR DESCRIPTION
Remove an extraneous semicolon from the `classifier-bayes.conf` template. Also adjust line spacing. 

Before: 

```
 backend = "sqlite3";


;
autolearn = true;
```

After:

```
backend = "sqlite3";


autolearn = true;

```

